### PR TITLE
Initial Test Cases

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+# Docker Image Test Cases
+
+This directory contains `centos-atomic` base image test cases.
+
+### Test Run Script
+Each test requires a `run.sh` script. The script will be executed as `bash <test name>/run.sh <image name>` where `image name` is the image being tested.
+
+### Directory Structure
+Each subdirectory contains a test case. We expect a `run.sh` script in each subdirectory along with a `README.md` file and other test assets.

--- a/tests/Readme.md
+++ b/tests/Readme.md
@@ -1,1 +1,0 @@
-create a dir and drop in a Dockerfile and a test.sh bash script to test it

--- a/tests/build-microdnf/README.md
+++ b/tests/build-microdnf/README.md
@@ -1,0 +1,3 @@
+# Docker Image Test Case: build-microdnf
+
+This test case builds a simple container from the `centos-atomic` base image with the `epel-release` package installed via `microdnf`.

--- a/tests/build-microdnf/run.sh
+++ b/tests/build-microdnf/run.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Original Source: https://github.com/docker-library/official-images/blob/master/test/tests/no-hard-coded-passwords/run.sh
+set -e
+
+EXIT_CODE=0
+IMAGE=test/${RANDOM}
+
+cat <<EOF |
+FROM $1
+RUN microdnf -y install epel-release
+EOF
+docker build -t ${IMAGE} - || EXIT_CODE=1
+docker rmi -f ${IMAGE} || :
+
+exit ${EXIT_CODE}

--- a/tests/no-hard-coded-passwords/README.md
+++ b/tests/no-hard-coded-passwords/README.md
@@ -1,0 +1,3 @@
+# Docker Image Test Case: no-hard-coded-passwords
+
+This test case is derived from the [Docker Official Images Test Case](https://github.com/docker-library/official-images/blob/master/test/tests/no-hard-coded-passwords). We check if there are any hard coded passwords in the image.

--- a/tests/no-hard-coded-passwords/run.sh
+++ b/tests/no-hard-coded-passwords/run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+IFS=$'\n'
+userPasswds=( $(docker run --rm --user 0:0 --entrypoint cut "$1" -d: -f1-2 /etc/passwd) )
+userShadows=()
+if echo "${userPasswds[*]}" | grep -qE ':x$'; then
+	userShadows=( $(docker run --rm --user 0:0 --entrypoint cut "$1" -d: -f1-2 /etc/shadow || true) )
+fi
+unset IFS
+
+declare -A passwds=()
+for userPasswd in "${userPasswds[@]}"; do
+	user="${userPasswd%%:*}"
+	pass="${userPasswd#*:}"
+	passwds[$user]="$pass"
+done
+for userShadow in "${userShadows[@]}"; do
+	user="${userShadow%%:*}"
+	if [ "${passwds[$user]}" = 'x' ]; then
+		pass="${userShadow#*:}"
+		passwds[$user]="$pass"
+	fi
+done
+
+ret=0
+for user in "${!passwds[@]}"; do
+	pass="${passwds[$user]}"
+
+	if [ -z "$pass" -o '*' = "$pass" ]; then
+		# '*' and '' mean no password
+		continue
+	fi
+
+	if [ "${pass:0:1}" = '!' ]; then
+		# '!anything' means "locked" password
+		#echo >&2 "warning: locked password detected for '$user': '$pass'"
+		continue
+	fi
+
+	if [ "${pass:0:1}" = '$' ]; then
+		# gotta be crypt ($id$salt$encrypted), must be a fail
+		echo >&2 "error: crypt password detected for '$user': '$pass'"
+		ret=1
+		continue
+	fi
+
+	echo >&2 "warning: garbage password detected for '$user': '$pass'"
+done
+
+exit "$ret"

--- a/tests/override-cmd/README.md
+++ b/tests/override-cmd/README.md
@@ -1,0 +1,3 @@
+# Docker Image Test Case: override-cmd
+
+This test case is derived from the [Docker Official Images Test Case](https://github.com/docker-library/official-images/tree/master/test/tests/override-cmd). We check if the default entrypoint and command can be overridden.

--- a/tests/override-cmd/run.sh
+++ b/tests/override-cmd/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Original Source: https://github.com/docker-library/official-images/tree/master/test/tests/override-cmd
+set -eo pipefail
+
+image="$1"
+
+# test that we can override the CMD with echo
+# https://github.com/docker-library/official-images/blob/d28cb89e79417cac50c2a8ae163a9b3b79167f79/README.md#consistency
+
+hello="world-$RANDOM-$RANDOM"
+
+# test first with --entrypoint to verify that we even have echo (tests for single-binary images FROM scratch, essentially)
+if ! testOutput="$(docker run --rm --entrypoint echo "$image" "Hello $hello" 2>/dev/null)"; then
+	echo >&2 'image does not appear to contain "echo" -- assuming single-binary image'
+	exit
+fi
+[ "$testOutput" = "Hello $hello" ]
+
+# now test with normal command to verify the default entrypoint is OK
+output="$(docker run --rm "$image" echo "Hello $hello")"
+[ "$output" = "Hello $hello" ]

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,7 +2,8 @@
 set -e
 
 TEST_DIR="$(readlink -f "$(dirname "${BASH_SOURCE}")")"
-IMAGE_TAR="$(readlink -f "$(dirname ${TEST_DIR})")/centos_atomic.tar"
+IMAGE_TAR_NAME="${IMAGE_TAR_NAME:-centos_atomic.tar}"
+IMAGE_TAR="${1:-$(readlink -f "$(dirname ${TEST_DIR})")/${IMAGE_TAR_NAME}}"
 IMAGE_NAME=build/centos-atomic:${RANDOM}
 
 function log() {

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -36,4 +36,8 @@ do
   log "[${test_name}] Completed test" "${result}"
 done
 
+# clean up after tests
+log "Deleting ${IMAGE_NAME}"
+docker rmi -f ${IMAGE_NAME} || :
+
 exit ${EXIT_CODE}

--- a/tests/shellshock/README.md
+++ b/tests/shellshock/README.md
@@ -1,0 +1,3 @@
+# Docker Image Test Case: shellshock
+
+This test case is derived from the [Docker Official Images Test Case](https://github.com/docker-library/official-images/tree/master/test/tests/cve-2014--shellshock). The intention here is to ensure that the image is not vulnerable to [Shellshock vulnerability](https://access.redhat.com/announcements/1210053).

--- a/tests/shellshock/run.sh
+++ b/tests/shellshock/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Original Source: https://github.com/docker-library/official-images/blob/master/test/tests/cve-2014--shellshock/run.sh
+set -e
+
+DIR="$(readlink -f "$(dirname "$BASH_SOURCE")")"
+docker run --rm -i --entrypoint bash \
+	local/centos-atomic <${DIR}/shellshock_test.sh

--- a/tests/shellshock/shellshock_test.sh
+++ b/tests/shellshock/shellshock_test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+EXITCODE=0
+
+# CVE-2014-6271
+CVE20146271=$(env 'x=() { :;}; echo vulnerable' 'BASH_FUNC_x()=() { :;}; echo vulnerable' bash -c "echo test" 2>&1 | grep 'vulnerable' | wc -l)
+
+echo -n "CVE-2014-6271 (original shellshock): "
+if [ $CVE20146271 -gt 0 ]; then
+	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+1))
+else
+	echo -e "\033[92mnot vulnerable\033[39m"
+fi
+
+# CVE-2014-6277
+# it is fully mitigated by the environment function prefix passing avoidance
+CVE20146277=$((shellshocker="() { x() { _;}; x() { _;} <<a; }" bash -c date 2>/dev/null || echo vulnerable) | grep 'vulnerable' | wc -l)
+
+echo -n "CVE-2014-6277 (segfault): "
+if [ $CVE20146277 -gt 0 ]; then
+	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+2))
+else
+	echo -e "\033[92mnot vulnerable\033[39m"
+fi
+
+# CVE-2014-6278
+CVE20146278=$(shellshocker='() { echo vulnerable; }' bash -c shellshocker 2>/dev/null | grep 'vulnerable' | wc -l)
+
+echo -n "CVE-2014-6278 (Florian's patch): "
+if [ $CVE20146278 -gt 0 ]; then
+	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+4))
+else
+	echo -e "\033[92mnot vulnerable\033[39m"
+fi
+
+# CVE-2014-7169
+CVE20147169=$((cd /tmp; rm -f /tmp/echo; env X='() { (a)=>\' bash -c "echo echo nonvuln" 2>/dev/null; [[ "$(cat echo 2> /dev/null)" == "nonvuln" ]] && echo "vulnerable" 2> /dev/null) | grep 'vulnerable' | wc -l)
+
+echo -n "CVE-2014-7169 (taviso bug): "
+if [ $CVE20147169 -gt 0 ]; then
+	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+8))
+else
+	echo -e "\033[92mnot vulnerable\033[39m"
+fi
+
+# CVE-2014-7186
+CVE20147186=$((bash -c 'true <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF <<EOF' 2>/dev/null || echo "vulnerable") | grep 'vulnerable' | wc -l)
+
+echo -n "CVE-2014-7186 (redir_stack bug): "
+if [ $CVE20147186 -gt 0 ]; then
+	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+16))
+else
+	echo -e "\033[92mnot vulnerable\033[39m"
+fi
+
+# CVE-2014-7187
+CVE20147187=$(((for x in {1..200}; do echo "for x$x in ; do :"; done; for x in {1..200}; do echo done; done) | bash || echo "vulnerable") | grep 'vulnerable' | wc -l)
+
+echo -n "CVE-2014-7187 (nested loops off by one): "
+if [ $CVE20147187 -gt 0 ]; then
+	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+32))
+else
+	echo -e "\033[92mnot vulnerable\033[39m"
+fi
+
+# CVE-2014-////
+CVE2014=$(env X=' () { }; echo vulnerable' bash -c 'date' | grep 'vulnerable' | wc -l)
+
+echo -n "CVE-2014-//// (exploit 3 on http://shellshocker.net/): "
+if [ $CVE2014 -gt 0 ]; then
+	echo -e "\033[91mVULNERABLE\033[39m"
+	EXITCODE=$((EXITCODE+64))
+else
+	echo -e "\033[92mnot vulnerable\033[39m"
+fi
+
+exit $EXITCODE

--- a/tests/utc/README.md
+++ b/tests/utc/README.md
@@ -1,0 +1,3 @@
+# Docker Image Test Case: utc
+
+This test case is derived from the [Docker Official Images Test Case](https://github.com/docker-library/official-images/tree/master/test/tests/utc). We check if the default time zone is UTC.

--- a/tests/utc/run.sh
+++ b/tests/utc/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+# Original Source: https://github.com/docker-library/official-images/blob/master/test/tests/utc/run.sh
+set -e
+
+[ "$(docker run --rm --entrypoint date "$1" +%Z)" == "UTC" ]


### PR DESCRIPTION
Added the following test cases:
* utc
* no-hard-coded-passwords
* shellshock
* override-cmd
* build-microdnf

All but the last one replicates Docker Official Library's [global test cases](https://github.com/docker-library/official-images/blob/master/test/config.sh#L4). Resolves #3,