### PR TITLE
 kickstart: clean up

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ yum -y install ${INSTALL_PKGS2};
 systemctl enable libvirtd && systemctl start libvirtd;
 
 virt-install --name ${VM_DOMAIN} --noreboot --memory 4096 --vcpus 1,cpuset=auto \
-     --disk size=2,sparse=no,format=raw --network network=${VM_NETWORK} \
+     --disk size=4,sparse=no,format=raw --network network=${VM_NETWORK} \
      --graphics=none --console pty,target_type=serial \
      --location ${CENTOS_INSTALL_SOURCE_URL} --extra-args "console=ttyS0,115200n8 serial ks=${KS_FILE_URL}";
 

--- a/tests/shellshock/run.sh
+++ b/tests/shellshock/run.sh
@@ -4,4 +4,4 @@ set -e
 
 DIR="$(readlink -f "$(dirname "$BASH_SOURCE")")"
 docker run --rm -i --entrypoint bash \
-	local/centos-atomic <${DIR}/shellshock_test.sh
+	$1 <${DIR}/shellshock_test.sh


### PR DESCRIPTION
- reorder tasks and remove workarounds
- enforce removal of packages in post install script

It was noticed when rebuilding the image, caused the image to almost double in size. Used the rhel-atomic image as reference for what packages are required and worked the difference from the built image.

Note this includes changes from #9.