### PR TITLE
Updating scripts to use zipped tarballs, instead of normal tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_REPO       ?= docker.io
 DOCKER_IMAGE_NAME ?= centos-atomic
 DOCKER_IMAGE_TAG  ?= latest
 DOCKER_IMAGE      ?= $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
-TAR               ?= centos_atomic.tar
+TAR               ?= centos_atomic.tar.gz
 
 _VM_DOMAIN        := centos_atomic_image
 _VM_POOL          := default

--- a/build.sh
+++ b/build.sh
@@ -10,12 +10,12 @@ fi
 
 # Initialize variables
 INSTALL_PKGS1="libvirt-*";
-INSTALL_PKGS2="virt-install libguestfs libguestfs-tools-c";
+INSTALL_PKGS2="gzip virt-install libguestfs libguestfs-tools-c";
 KS_FILE_URL="https://raw.githubusercontent.com/kbsingh/atomic-container/master/centos-atomic-container.ks";
 CENTOS_INSTALL_SOURCE_URL=${CENTOS_INSTALL_SOURCE_URL-"http://mirror.centos.org/centos/7/os/x86_64"};
 VM_DOMAIN=${VM_DOMAIN-"centos_atomic_image"};
 VM_NETWORK=${VM_NETWORK-"default"};
-IMAGE_TAR_NAME=${IMAGE_TAR_NAME-"centos_atomic.tar"};
+IMAGE_TAR_NAME=${IMAGE_TAR_NAME-"centos_atomic.tar.gz"};
 
 # Install necessary packages
 yum -y install ${INSTALL_PKGS1};
@@ -29,4 +29,4 @@ virt-install --name ${VM_DOMAIN} --noreboot --memory 4096 --vcpus 1,cpuset=auto 
      --graphics=none --console pty,target_type=serial \
      --location ${CENTOS_INSTALL_SOURCE_URL} --extra-args "console=ttyS0,115200n8 serial ks=${KS_FILE_URL}";
 
-virt-tar-out -d "${VM_DOMAIN}" / ${IMAGE_TAR_NAME};
+virt-tar-out -d "${VM_DOMAIN}" / - | gzip --best > ${IMAGE_TAR_NAME};

--- a/cccp-prebuild.sh
+++ b/cccp-prebuild.sh
@@ -3,7 +3,7 @@
 set -eux;
 
 DOCKERFILE="Dockerfile";
-export IMAGE_TAR_NAME="centos_atomic.tar";
+export IMAGE_TAR_NAME="centos_atomic.tar.gz";
 
 bash build.sh
 cat >${DOCKERFILE} <<EOF

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 TEST_DIR="$(readlink -f "$(dirname "${BASH_SOURCE}")")"
-IMAGE_TAR_NAME="${IMAGE_TAR_NAME:-centos_atomic.tar}"
+IMAGE_TAR_NAME="${IMAGE_TAR_NAME:-centos_atomic.tar.gz}"
 IMAGE_TAR="${1:-$(readlink -f "$(dirname ${TEST_DIR})")/${IMAGE_TAR_NAME}}"
 IMAGE_NAME=build/centos-atomic:${RANDOM}
 


### PR DESCRIPTION
  This changes the scripts to work with zipped tarballs, almost reducing tarball size by half.

This is primarily to make it easier to build this container on CentOS pipeline as files larger than 100 mb are not allowed.