### PR TITLE
sync w/ upstream minimal container

### DIFF
--- a/centos-atomic-container.ks
+++ b/centos-atomic-container.ks
@@ -7,163 +7,122 @@
 # We assume this runs on a CentOS Linux 7/x86_64 machine, with virt ( or nested virt ) 
 # enabled, use the build.sh script to build your own for testing
 
-# text don't use cmdline -- https://github.com/rhinstaller/anaconda/issues/931
-cmdline
-bootloader --disabled
-timezone --isUtc --nontp Etc/UTC
-rootpw --lock --iscrypted locked
-
-keyboard us
-network --bootproto=dhcp --device=link --activate --onboot=on
-poweroff
-
-zerombr
-clearpart --all
-part /boot/efi --fstype="vfat" --size=100
-part / --fstype ext4 --grow
-
-# Add nessasary repo for microdnf
-repo --name="microdnf" --baseurl="https://buildlogs.centos.org/cah-0.0.1" --cost=100
+#version=CentOS7
+# Keyboard layouts
+keyboard 'us'
+# Reboot after installation
+reboot
+# Root password
+rootpw --iscrypted --lock locked
+# System language
+lang en_US
+user --name=none
+# Firewall configuration
+firewall --disabled
+repo --name="microdnf" --baseurl="http://mirror.centos.org/centos/7/atomic/x86_64" --cost=100
 repo --name="updates" --baseurl="http://mirror.centos.org/centos/7/updates/x86_64"
 
-%packages --excludedocs --instLangs=en --nocore
+# System timezone
+timezone UTC --isUtc --nontp
+# System bootloader configuration
+bootloader --disabled
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all
+# Disk partitioning information
+part / --fstype="ext4" --grow
+
+%post --logfile /var/log/anaconda/anaconda-post.log
+
+# remove the user anaconda forces us to make
+userdel -r none
+
+# Set the language rpm nodocs transaction flag persistently in the
+# image yum.conf and rpm macros
+
+LANG="en_US"
+echo "%_install_lang $LANG" > /etc/rpm/macros.image-language-conf
+
+awk '(NF==0&&!done){print "override_install_langs='$LANG'\ntsflags=nodocs";done=1}{print}' \
+    < /etc/yum.conf > /etc/yum.conf.new
+mv /etc/yum.conf.new /etc/yum.conf
+
+#systemd wrongly expects "unpopulated /etc" when /etc/machine-id does not exist
+#let's leave machine-id empty
+cat /dev/null > /etc/machine-id
+
+#https://bugzilla.redhat.com/show_bug.cgi?id=1235969
+#rm -f /etc/fstab
+#this is not possible, guestmount needs fstab => brew build crashes without it
+#fstab is removed in TDL when tar-ing files
+
+rm -f /usr/lib/locale/locale-archive
+#setup at least some locale, https://bugzilla.redhat.com/show_bug.cgi?id=1129697
+localedef -v -c -i en_US -f UTF-8 en_US.UTF-8
+
+#https://bugzilla.redhat.com/show_bug.cgi?id=1201663
+rm -f /etc/systemd/system/multi-user.target.wants/rhsmcertd.service
+
+#content of /run can not be prepared if /run is tmpfs (disappears on reboot)
+umount /run
+systemd-tmpfiles --create --boot
+
+rpm -e acl audit-libs binutils cpio cracklib cracklib-dicts cryptsetup-libs dbus dbus-libs device-mapper device-mapper-libs diffutils dracut elfutils-libs gzip hardlink kmod kmod-libs kpartx libcap-ng libpwquality libsemanage libuser libutempter pam procps-ng qrencode-libs shadow-utils systemd systemd-libs tar ustr util-linux xz qemu-guest-agent
+
+#create /etc/yum.repos.d, microdnf needs it but does not provide it
+mkdir -p /etc/yum.repos.d/
+
+rm /usr/share/gnupg/help*.txt -f
+KEEPLANG=en_US
+for dir in locale i18n; do
+    find /usr/share/${dir} -mindepth  1 -maxdepth 1 -type d -not \( -name "${KEEPLANG}" -o -name POSIX \) -exec rm -rf {} +
+done
+rm /usr/lib/rpm/rpm.daily
+rm /usr/lib64/nss/unsupported-tools/ -rf
+rm /usr/share/gcc*/python -rf
+rm /usr/sbin/{glibc_post_upgrade.x86_64,sln}
+#let us not lie that blatantly
+#ln /usr/bin/ln /usr/sbin/sln
+rm -rf /var/lib/yum
+rm -rf /var/cache/* /var/log/* /tmp/*
+rm -rf /usr/lib/udev /etc/yum /etc/dbus-1 /usr/share/dbus-1
+rm -rf /usr/share/icons/*
+
+#some random not-that-useful binaries
+rm -f /usr/bin/oldfind
+rm -f /usr/bin/pinky
+rm -f /usr/bin/script
+
+
+#we lose presets by removing /usr/lib/systemd but we do not care
+rm -rf /usr/lib/systemd
+#https://bugzilla.redhat.com/show_bug.cgi?id=1476674 should not be affected
+
+#if you want to change the timezone, bind-mount it from the host or reinstall tzdata
+rm -f /etc/localtime
+mv /usr/share/zoneinfo/UTC /etc/localtime
+rm -rf  /usr/share/zoneinfo
+
+#udev hardware database not needed in a container
+rm -f /etc/udev/hwdb.bin
+rm -rf /usr/lib/udev/hwdb.d/*
+
+
+rm -rf /var/cache/yum/*
+rm -f /tmp/ks-script*
+
+%end
+
+%packages --excludedocs --nobase --nocore --instLangs=en
 bash
 centos-release
 microdnf
--kernel
+systemd
 -e2fsprogs
--libss # used by e2fsprogs
--fuse-libs
--audit-libs
--diffutils
--libmnl
--libnetfilter_conntrack
--iproute
--kmod-libs
--snappy
--libsemanage
--hardlink
--lzo
--gzip
--libblkid
--cracklib-dicts
--pam
--procps-ng
--binutils
--bind-libs-lite
--dhcp-common
--dbus-libs
--device-mapper
--cryptsetup-libs
--kmod
--dbus
--initscripts
--dracut-network
--ethtool
--gpg-pubkey
--basesystem
--bind-license
--libuuid
--cpio
--libnfnetlink
--hostname
--iptables
--tar
--GeoIP
--sysvinit-tools
--ustr
--qrencode-libs
--shadow-utils
--cracklib
--libmount
--libpwquality
--systemd-libs
--libutempter
--dhcp-libs
--libuser
--kpartx
--device-mapper-libs
--dracut
--systemd
--iputils
--dhclient
+-firewalld
+-kernel
 -kexec-tools
--dosfstools
-
-%end
-
-%post --interpreter=/usr/bin/sh --nochroot --erroronfail --log=/mnt/sysimage/root/anaconda-post-nochroot.log
-set -eux
-
-# Set install langs macro so that new rpms that get installed will
-# only install langs that we limit it to.
-LANG="en_US"
-echo "%_install_langs $LANG" > /etc/rpm/macros.image-language-conf
-# https://bugzilla.redhat.com/show_bug.cgi?id=1400682
-echo "Import RPM GPG key"
-releasever=$(rpm -q --qf '%{version}\n' centos-release)
-rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-$releasever
-echo "# fstab intentionally empty for containers" > /etc/fstab
-
-# Remove machine-id on pre generated images
-rm -fv /etc/machine-id
-touch /etc/machine-id
-
-# remove some random help txt files
-rm -fv usr/share/gnupg/help*.txt
-
-# Pruning random things
-rm usr/lib/rpm/rpm.daily
-rm -rfv usr/lib64/nss/unsupported-tools/  # unsupported
-
-# Statically linked crap
-rm -fv usr/sbin/{glibc_post_upgrade.x86_64,sln}
-ln usr/bin/ln usr/sbin/sln
-
-# Remove some dnf info
-rm -rfv /var/lib/yum
-
-# don't need icons
-rm -rfv /usr/share/icons/*
-
-#some random not-that-useful binaries
-rm -fv /usr/bin/pinky
-
-# we lose presets by removing /usr/lib/systemd but we do not care
-rm -rfv /usr/lib/systemd
-
-# if you want to change the timezone, bind-mount it from the host or reinstall tzdata
-rm -fv /etc/localtime
-mv /usr/share/zoneinfo/UTC /etc/localtime
-rm -rfv  /usr/share/zoneinfo
-
-# Final pruning
-rm -rfv var/cache/* var/log/* tmp/*
-
-%end
-
-%post --interpreter=/usr/bin/sh --nochroot --erroronfail --log=/mnt/sysimage/root/anaconda-post-nochroot.log
-set -eux
-
-# https://bugzilla.redhat.com/show_bug.cgi?id=1343138
-# Fix /run/lock breakage since it's not tmpfs in docker
-# This unmounts /run (tmpfs) and then recreates the files
-# in the /run directory on the root filesystem of the container
-# NOTE: run this in nochroot because "umount" does not exist in chroot
-umount /mnt/sysimage/run
-# The file that specifies the /run/lock tmpfile is
-# /usr/lib/tmpfiles.d/legacy.conf, which is part of the systemd
-# rpm that isn't included in this image. We'll create the /run/lock
-# file here manually with the settings from legacy.conf
-# NOTE: chroot to run "install" because it is not in anaconda env
-chroot /mnt/sysimage install -d /run/lock -m 0755 -o root -g root
-
-
-# See: https://bugzilla.redhat.com/show_bug.cgi?id=1051816
-# NOTE: run this in nochroot because "find" does not exist in chroot
-KEEPLANG=en_US
-for dir in locale i18n; do
-    find /mnt/sysimage/usr/share/${dir} -mindepth  1 -maxdepth 1 -type d -not \( -name "${KEEPLANG}" -o -name POSIX \) -exec rm -rfv {} +
-done
+-xfsprogs
 
 %end


### PR DESCRIPTION
I grabbed the ks from registry.access.redhat.com/rhel7-atomic and adapted it a bit for centos, in the spirit of #12. Also, this results in a container that's 78 MB vs 157 MB for registry.centos.org/kbsingh/centos7-atomic.

@mohammedzee1000 